### PR TITLE
[feat] use backoff code from OpenAI

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -1,11 +1,63 @@
 import os
 from typing import Dict, Any
 import openai
+import random
+import time
+import logging
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+
+# from https://github.com/openai/openai-cookbook/blob/main/examples/How_to_handle_rate_limits.ipynb
+def retry_with_exponential_backoff(
+    func,
+    initial_delay: float = 1,
+    exponential_base: float = 2,
+    jitter: bool = True,
+    max_retries: int = 10,
+    errors: tuple = (openai.error.RateLimitError,),
+):
+    """Retry a function with exponential backoff."""
+
+    def wrapper(*args, **kwargs):
+        # Initialize variables
+        num_retries = 0
+        delay = initial_delay
+
+        # Loop until a successful response or max_retries is hit or an exception is raised
+        while True:
+            try:
+
+                return func(*args, **kwargs)
+
+            # Retry on specified errors
+            except errors as e:
+                # Increment retries
+                num_retries += 1
+
+                # Check if max retries has been reached
+                if num_retries > max_retries:
+                    raise Exception(
+                        f"Maximum number of retries ({max_retries}) exceeded."
+                    )
+
+                # Increment the delay
+                delay *= exponential_base * (1 + jitter * random.random())
+
+                # Sleep for the delay
+                time.sleep(delay)
+                
+                
+
+            # Raise exceptions for any errors not specified
+            except Exception as e:
+                raise e
+
+    return wrapper
+
 class OpenaiAPIWrapper:
     @staticmethod
+    @retry_with_exponential_backoff
     def call(prompt: str, max_tokens: int, engine: str, stop_token: str, temperature: float) -> dict:
         response = openai.Completion.create(
             engine=engine,

--- a/prompts/utils.py
+++ b/prompts/utils.py
@@ -156,30 +156,3 @@ def make_task_file_from_config(task_config: TaskConfig) -> pd.DataFrame:
     # davinci doesn't like prompts that end with a space
     task_df["answer"] = task_df["target"]
     return task_df[["question", "answer"]]
-
-
-def maintain_request_per_minute(
-    num_requests: int, time_begin: float, max_requests_per_min: int, task_idx: int, model_name: str
-) -> float:
-    """Maintains the number of requests per minute to be less than max_requests_per_min.
-    This is required for models like Codex.
-    """
-
-    request_per_minute = get_request_per_minute(num_requests, time_begin)
-    logging.info("\n")
-    while request_per_minute > max_requests_per_min:
-        logging.info(
-            f"Task {task_idx} > Sleeping! (Requests/minute = {request_per_minute:.2f} > {max_requests_per_min:.2f})"
-        )
-        if "code" in model_name:
-            time.sleep(10)
-        request_per_minute = get_request_per_minute(num_requests, time_begin)
-    if "code" in model_name:
-        time.sleep(4)
-    return request_per_minute
-
-
-def get_request_per_minute(num_request: int, begin_time: float) -> float:
-    elapsed_time = time.time() - begin_time
-    request_per_minute = (num_request / elapsed_time) * 60
-    return request_per_minute


### PR DESCRIPTION
This PR moves the waiting logic to a decorator using [this implementation](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_handle_rate_limits.ipynb). It helps make the query loop cleaner and the waiting times are adaptive, hopefully increasing throughput.